### PR TITLE
Remove scrollbars unless needed

### DIFF
--- a/src/css/_code.css
+++ b/src/css/_code.css
@@ -1,7 +1,6 @@
 pre, .pre  {
   overflow-x: auto;
   overflow-y: hidden;
-  overflow:   scroll;
 }
 
 


### PR DESCRIPTION
Ananke has a very minimal design but code sections were including
horizontal and vertical scrollbars even when there is only a single line
of code. I feel that removing them unless necessary leads to a less
cluttered look with no downsides.